### PR TITLE
This commit adds a score configuration (anti spam) option to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Laravel Invisible reCAPTCHA v3
 
 ## Support
 
-Laravel 10 / 11, PHP `*8.0`.
+Laravel 10 / 11 / 12, PHP `*8.0`.
 
 ## Installation
 
@@ -118,147 +118,9 @@ Add `'g-recaptcha-response' => 'required|captcha'` to rules array.
 $validate = Validator::make(Input::all(), [
     'g-recaptcha-response' => 'required|captcha'
 ]);
-
 ```
 
-## CodeIgniter 3.x
-
-set in application/config/config.php :
-```php
-$config['composer_autoload'] = TRUE;
-```
-
-add lines in application/config/config.php :
-```php
-$config['recaptcha.sitekey'] = 'sitekey'; 
-$config['recaptcha.secret'] = 'secretkey';
-// optional
-$config['recaptcha.options'] = [
-    'hideBadge' => false,
-    'dataBadge' => 'bottomright',
-    'timeout' => 5,
-    'debug' => false
-];
-```
-
-In controller, use:
-```php
-$data['captcha'] = new \AlbertCht\InvisibleReCaptcha\InvisibleReCaptcha(
-    $this->config->item('recaptcha.sitekey'),
-    $this->config->item('recaptcha.secret'),
-    $this->config->item('recaptcha.options'),
-);
-```
-
-In view, in your form:
-```php
-<?php echo $captcha->render(); ?>
-```
-
-Then back in your controller you can verify it:
-```php
-$captcha->verifyResponse($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-```
-
-## Without Laravel or CodeIgniter
-
-Checkout example below:
-
-```php
-<?php
-
-require_once "vendor/autoload.php";
-
-$siteKey = 'sitekey';
-$secretKey = 'secretkey';
-// optional
-$options = [
-    'hideBadge' => false,
-    'dataBadge' => 'bottomright',
-    'timeout' => 5,
-    'debug' => false
-];
-$captcha = new \AlbertCht\InvisibleReCaptcha\InvisibleReCaptcha($siteKey, $secretKey, $options);
-
-// you can override single option config like this
-$captcha->setOption('debug', true);
-
-if (!empty($_POST)) {
-    var_dump($captcha->verifyResponse($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']));
-    exit();
-}
-
-?>
-
-<form action="?" method="POST">
-    <?php echo $captcha->render(); ?>
-    <button type="submit">Submit</button>
-</form>
-```
-
-## Take Control of Submit Function
-Use this function only when you need to take all control after clicking submit button. Recaptcha validation will not be triggered if you return false in this function.
-
-```javascript
-_beforeSubmit = function(e) {
-    console.log('submit button clicked.');
-    // do other things before captcha validation
-    // e represents reference to original form submit event
-    // return true if you want to continue triggering captcha validation, otherwise return false
-    return false;
-}
-```
-
-## Customize Submit Function
-If you want to customize your submit function, for example: doing something after click the submit button or changing your submit to ajax call, etc.
-
-The only thing you need to do is to implement `_submitEvent` in javascript
-```javascript
-_submitEvent = function() {
-    console.log('submit button clicked.');
-    // write your logic here
-    // submit your form
-    _submitForm();
-}
-```
-Here's an example to use an ajax submit (using jquery selector)
-```javascript
-_submitEvent = function() {
-    $.ajax({
-        type: "POST",
-        url: "{{route('message.send')}}",
-         data: {
-            "name": $("#name").val(),
-            "email": $("#email").val(),
-            "content": $("#content").val(),
-            // important! don't forget to send `g-recaptcha-response`
-            "g-recaptcha-response": $("#g-recaptcha-response").val()
-        },
-        dataType: "json",
-        success: function(data) {
-            // success logic
-        },
-        error: function(data) {
-            // error logic
-        }
-    });
-};
-```
 ## Example Repository
 Repo: https://github.com/albertcht/invisible-recaptcha-example
 
 This repo demonstrates how to use this package with ajax way.
-
-## Showcases
-
-* [Laravel Boilerplate](https://github.com/Labs64/laravel-boilerplate)
-
-## Credits 
-
-* anhskohbo (the author of no-captcha package)
-* [Contributors](https://github.com/albertcht/invisible-recaptcha/graphs/contributors)
-
-## Support on Beerpay
-Hey dude! Help me out for a couple of :beers:!
-
-[![Beerpay](https://beerpay.io/albertcht/invisible-recaptcha/badge.svg?style=beer-square)](https://beerpay.io/albertcht/invisible-recaptcha)  [![Beerpay](https://beerpay.io/albertcht/invisible-recaptcha/make-wish.svg?style=flat-square)](https://beerpay.io/albertcht/invisible-recaptcha?focus=wish)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In reCAPTCHA v2, users need to click the button: "I'm not a robot" to prove they
 ## Installation
 
 ```
-composer require albertcht/invisible-recaptcha
+composer require f9webltd/invisible-recaptcha
 ```
 
 ## Laravel 5

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Invisible reCAPTCHA
 ==========
 ![php-badge](https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg)
-[![packagist-badge](https://img.shields.io/packagist/v/albertcht/invisible-recaptcha.svg)](https://packagist.org/packages/albertcht/invisible-recaptcha)
-[![Total Downloads](https://poser.pugx.org/albertcht/invisible-recaptcha/downloads)](https://packagist.org/packages/albertcht/invisible-recaptcha)
-[![travis-badge](https://api.travis-ci.org/albertcht/invisible-recaptcha.svg?branch=master)](https://travis-ci.org/albertcht/invisible-recaptcha)
+[![packagist-badge](https://img.shields.io/packagist/v/f9webltd/invisible-recaptcha.svg)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
+[![Total Downloads](https://poser.pugx.org/f9webltd/invisible-recaptcha/downloads)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
+[![travis-badge](https://api.travis-ci.org/f9webltd/invisible-recaptcha.svg?branch=master)](https://travis-ci.org/f9webltd/invisible-recaptcha)
 
 ![invisible_recaptcha_demo](http://i.imgur.com/1dZ9XKn.png)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Laravel Invisible reCAPTCHA v3
 
 ## Background
 
-28/06/2024 - the original repository has not been updated for over 2 years and lacks Laravel 11 support and a [critical PR](https://github.com/albertcht/invisible-recaptcha/pull/173) relating to patch the recent polyfillio[dot]io attack. This fork includes both fixes and drops support for old Laravel and PHP versions. I plan to tidy up the forked repository, add GitHub workflows and set a different namespace.
+28/06/2024 - the [original repository](https://github.com/albertcht/invisible-recaptcha) has not been updated for over 2 years and lacks Laravel 11 support and a [critical PR](https://github.com/albertcht/invisible-recaptcha/pull/173) relating to patch the recent polyfillio[dot]io attack. This fork includes both fixes and drops support for old Laravel and PHP versions. I plan to tidy up the forked repository, add GitHub workflows and set a different namespace.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,19 @@
-Invisible reCAPTCHA
+Invisible reCAPTCHA (Forked 28/06/2024,)
 ==========
-![php-badge](https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg)
-[![packagist-badge](https://img.shields.io/packagist/v/f9webltd/invisible-recaptcha.svg)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
-[![Total Downloads](https://poser.pugx.org/f9webltd/invisible-recaptcha/downloads)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
-[![travis-badge](https://api.travis-ci.org/f9webltd/invisible-recaptcha.svg?branch=master)](https://travis-ci.org/f9webltd/invisible-recaptcha)
+[![Packagist PHP Version](https://img.shields.io/packagist/php-v/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
+[![Packagist Version](https://img.shields.io/packagist/v/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
 
 ![invisible_recaptcha_demo](http://i.imgur.com/1dZ9XKn.png)
 
-## Why Invisible reCAPTCHA?
+## Support
 
-Invisible reCAPTCHA is an improved version of reCAPTCHA v2(no captcha).
-In reCAPTCHA v2, users need to click the button: "I'm not a robot" to prove they are human. In invisible reCAPTCHA, there will be not embed a captcha box for users to click. It's totally invisible! Only the badge will show on the buttom of the page to hint users that your website is using this technology. (The badge could be hidden, but not suggested.)
-
-## Notice
-
-* The master branch doesn't support multi captchas feature, please use `multi-forms` branch if you need it. (**Most of the time you are misusing recaptcha when you try to put multiple captchas in one page.**)
+Laravel 10 / 11, PHP `*8.0`.
 
 ## Installation
 
 ```
 composer require f9webltd/invisible-recaptcha
 ```
-
-## Laravel 5
 
 ### Setup
 
@@ -31,8 +22,6 @@ Add ServiceProvider to the providers array in `app/config/app.php`.
 ```
 AlbertCht\InvisibleReCaptcha\InvisibleReCaptchaServiceProvider::class,
 ```
-
-> It also supports package discovery for Laravel 5.5.
 
 ### Configuration
 Before you set your config, remember to choose `invisible reCAPTCHA` while applying for keys.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-Invisible reCAPTCHA (Forked 28/06/2024,)
+Laravel Invisible reCAPTCHA v3
 ==========
 [![Packagist PHP Version](https://img.shields.io/packagist/php-v/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
 [![Packagist Version](https://img.shields.io/packagist/v/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
 
 ![invisible_recaptcha_demo](http://i.imgur.com/1dZ9XKn.png)
+
+## Background
+
+28/06/2024 - the original repository has not been updated for over 2 years and lacks Laravel 11 support and a [critical PR](https://github.com/albertcht/invisible-recaptcha/pull/173) relating to patch the recent polyfillio[dot]io attack. This fork includes both fixes and drops support for old Laravel and PHP versions. I plan to tidy up the forked repository, add GitHub workflows and set a different namespace.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Laravel Invisible reCAPTCHA v3
 ==========
 [![Packagist PHP Version](https://img.shields.io/packagist/php-v/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
 [![Packagist Version](https://img.shields.io/packagist/v/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
+[![Packagist License](https://img.shields.io/packagist/l/f9webltd/invisible-recaptcha?style=flat-square)](https://packagist.org/packages/f9webltd/invisible-recaptcha)
 
 ![invisible_recaptcha_demo](http://i.imgur.com/1dZ9XKn.png)
 
@@ -9,9 +10,13 @@ Laravel Invisible reCAPTCHA v3
 
 28/06/2024 - the [original repository](https://github.com/albertcht/invisible-recaptcha) has not been updated for over 2 years and lacks Laravel 11 support and a [critical PR](https://github.com/albertcht/invisible-recaptcha/pull/173) relating to patch the recent polyfillio[dot]io attack. This fork includes both fixes and drops support for old Laravel and PHP versions. I plan to tidy up the forked repository, add GitHub workflows and set a different namespace.
 
-## Support
+## Requirements
 
-Laravel 10 / 11 / 12, PHP `*8.0`.
+- PHP `^8.2`
+- Laravel `^11.0`, `^12.0` or `^13.0`
+
+The package supports actively supported Laravel releases as per the official [Laravel Support Policy](https://laravel.com/docs/master/releases#support-policy).
+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php": "^5.6.4 || ^7.0 || ^8.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/view": "^5.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/view": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/view": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/view": "^10.0|^11.0|^12.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "albertcht/invisible-recaptcha",
+    "name": "f9webltd/invisible-recaptcha",
     "description": "Invisible reCAPTCHA For Laravel.",
     "keywords": [
         "recaptcha",

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,20 @@
         {
             "name": "Albert Chen",
             "homepage": "https://www.albert-chen.com"
+        },
+        {
+            "name": "Rob Allport",
+            "homepage": "https://www.f9web.co.uk"
         }
     ],
     "require": {
-        "php": "^5.6.4 || ^7.0 || ^8.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/view": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "guzzlehttp/guzzle": "^6.2|^7.0"
+        "php": "^8.0",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/view": "^10.0|^11.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.3"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/view": "^10.0|^11.0|^12.0",
+        "php": "^8.2",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/view": "^11.0|^12.0|^13.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^10.5|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -10,7 +10,7 @@ class InvisibleReCaptcha
 {
     const API_URI = 'https://www.google.com/recaptcha/api.js';
     const VERIFY_URI = 'https://www.google.com/recaptcha/api/siteverify';
-    const POLYFILL_URI = 'https://cdn.polyfill.io/v2/polyfill.min.js';
+    const POLYFILL_URI = 'https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js';
     const DEBUG_ELEMENTS = [
         '_submitForm',
         '_captchaForm',

--- a/tests/CaptchaTest.php
+++ b/tests/CaptchaTest.php
@@ -66,7 +66,7 @@ class CaptchaTest extends TestCase
 
     public function testGetPolyfillJs()
     {
-        $js = 'https://cdn.polyfill.io/v2/polyfill.min.js';
+        $js = 'https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js';
 
         $this->assertEquals($js, $this->captcha->getPolyfillJs());
     }


### PR DESCRIPTION
This commit adds a new configuration option to the package, allowing developers to set the minimum score required for a successful verification. By default, the score is set to 0.5, but developers can now adjust this value to better suit their specific use case.